### PR TITLE
Fix README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ Where `./path/to/fintoc-react-native-0.3.1.tgz` corresponds to the path to the `
 If you want to create a new _release_, you can run:
 
 ```sh
-git switch master
+git switch main
 npm run bump! <major|minor|patch>
 ```
 
-This will create a new branch with the updated version from `master`.
+This will create a new branch with the updated version from `main`.
 
 ## Acknowledgements
 


### PR DESCRIPTION
## Description

The `README.md` file stated that you should use the `master` branch, but the _default_ branch is the `main` branch. This got fixed.

## Requirements

None.

## Additional changes

None.
