### PR TITLE
Move handlers to direct props

### DIFF
--- a/src/lib/core.tsx
+++ b/src/lib/core.tsx
@@ -5,7 +5,7 @@ import type { FintocWidgetWebViewPropsType } from '../types';
 import { FINTOC_WEBVIEW_URL, FINTOC_BASE_URLS } from './constants';
 import { buildQueryString, buildMessageHandler } from './utils';
 
-export const FintocWidgetWebView = ({ options, handlers }: FintocWidgetWebViewPropsType) => (
+export const FintocWidgetWebView = ({ options, ...handlers }: FintocWidgetWebViewPropsType) => (
   // eslint-disable-next-line no-use-before-define
   <View style={styles.wrapper}>
     <WebView

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,11 +2,13 @@ import { WebViewMessageEvent } from 'react-native-webview';
 import type { FintocWidgetEventHandlers, WebViewEventName } from '../types';
 import { EVENT_MAP } from './constants';
 
+const defaultHanlder = () => null;
+
 export const buildQueryString = (config: Record<string, string>): string => Object.keys(config).map((key) => `${key}=${config[key]}`).join('&');
 
 export const buildMessageHandler = (handlers: FintocWidgetEventHandlers) => (
   (event: WebViewMessageEvent) => {
     const eventName = event.nativeEvent.data as WebViewEventName;
-    return handlers[EVENT_MAP[eventName]]();
+    return (handlers[EVENT_MAP[eventName]] || defaultHanlder)();
   }
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,8 @@ export type WebViewEventName = 'fintocwidget://succeeded' | 'fintocwidget://exit
  * You can read more here: {@link https://docs.fintoc.com/docs/widget-webview-integration#webview-redirections}.
  */
 export interface FintocWidgetEventHandlers {
-  onSuccess: () => void
-  onExit: () => void
+  onSuccess?: () => void
+  onExit?: () => void
 }
 
 export type WebViewEventMap = Record<WebViewEventName, keyof FintocWidgetEventHandlers>
@@ -20,7 +20,6 @@ export type WebViewEventMap = Record<WebViewEventName, keyof FintocWidgetEventHa
 /**
  * The props for the Fintoc Widget WebView.
  */
-export interface FintocWidgetWebViewPropsType {
+export type FintocWidgetWebViewPropsType = FintocWidgetEventHandlers & {
   options: FintocWidgetOptions
-  handlers: FintocWidgetEventHandlers
 }


### PR DESCRIPTION
## Description

Now handlers are passed directly as `props` instead of as a `handlers` object.

## Requirements

None.

## Additional changes

None.
