### PR TITLE
[EXP-846] feat: Handle nested objects on `buildQueryString`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "build:scripts": "vite build",
     "build:types": "tsc --project tsconfig.build.json --emitDeclarationOnly",
     "lint": "eslint --ext .tx,.ts .",
-    "version:get": "node -p \"require('./package.json').version\""
+    "version:get": "node -p \"require('./package.json').version\"",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "peerDependencies": {
     "react": "*",

--- a/src/lib/__tests__/utils.test.ts
+++ b/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest';
+import { buildQueryString } from '../utils';
+
+describe('utils', () => {
+  describe('buildQueryString', () => {
+    describe('when config has string properties only', () => {
+      const simpleOptions = {
+        country: 'cl',
+        holder_type: 'individual',
+        product: 'payments',
+        public_key: 'pk_live_XXX',
+        username: '11111111-1',
+        widget_token: 'pi_XXX',
+      };
+      const simpleQueryString = 'country=cl&holder_type=individual&product=payments&public_key=pk_live_XXX&username=11111111-1&widget_token=pi_XXX';
+      test('parses the query string correctly', () => {
+        expect(buildQueryString(simpleOptions)).toEqual(simpleQueryString);
+      });
+    });
+
+    describe('when config has nested object properties', () => {
+      const nestedOptions = {
+        country: 'cl',
+        holder_type: 'individual',
+        product: 'payments',
+        public_key: 'pk_live_XXX',
+        username: {
+          editable: false,
+          value: '11111111-1',
+        },
+        widget_token: 'pi_XXX',
+      };
+      const nestedQueryString = 'country=cl&holder_type=individual&product=payments&public_key=pk_live_XXX&username[editable]=false&username[value]=11111111-1&widget_token=pi_XXX';
+      test('parses the query string correctly', () => {
+        expect(buildQueryString(nestedOptions)).toEqual(nestedQueryString);
+      });
+    });
+    describe('when config has array properties', () => {
+      const optionsWithArray = {
+        country: 'cl',
+        arrayOption: ['option1', 'option2', 'option3'],
+      };
+      const queryStringWithArray = 'country=cl&arrayOption[]=option1&arrayOption[]=option2&arrayOption[]=option3';
+      test('parses the query string correctly', () => {
+        expect(buildQueryString(optionsWithArray)).toEqual(queryStringWithArray);
+      });
+    });
+    describe('when config has array and nested object properties', () => {
+      const optionsWithArray = {
+        country: 'cl',
+        arrayOption: ['option1', 'option2', 'option3'],
+        username: {
+          editable: false,
+          value: '11111111-1',
+        },
+      };
+      const queryStringWithArray = 'country=cl&arrayOption[]=option1&arrayOption[]=option2&arrayOption[]=option3&username[editable]=false&username[value]=11111111-1';
+      test('parses the query string correctly', () => {
+        expect(buildQueryString(optionsWithArray)).toEqual(queryStringWithArray);
+      });
+    });
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,8 +4,9 @@ import { EVENT_MAP } from './constants';
 
 const defaultHanlder = () => null;
 
+type QueryValue = string | number | boolean;
 interface QueryObject {
-  [key: string]: string | number | boolean | QueryObject;
+  [key: string]: QueryValue | QueryObject | QueryValue[];
 }
 
 export const buildQueryString = (config: QueryObject, configKey?: string): string => {
@@ -14,9 +15,14 @@ export const buildQueryString = (config: QueryObject, configKey?: string): strin
   Object.entries(config).forEach(([key, value]) => {
     const nestedKey = configKey ? `${configKey}[${encodeURIComponent(key)}]` : encodeURIComponent(key);
     const valueIsObject = typeof value === 'object' && value !== null && !Array.isArray(value);
+    const valueIsArray = typeof value === 'object' && value !== null && Array.isArray(value);
 
     if (valueIsObject) {
       pairs.push(buildQueryString(value as QueryObject, nestedKey));
+    } else if (valueIsArray) {
+      value.forEach((element) => {
+        pairs.push(`${nestedKey}[]=${encodeURIComponent(String(element))}`);
+      });
     } else {
       pairs.push(`${nestedKey}=${encodeURIComponent(String(value))}`);
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,7 +4,26 @@ import { EVENT_MAP } from './constants';
 
 const defaultHanlder = () => null;
 
-export const buildQueryString = (config: Record<string, string>): string => Object.keys(config).map((key) => `${key}=${config[key]}`).join('&');
+interface QueryObject {
+  [key: string]: string | number | boolean | QueryObject;
+}
+
+export const buildQueryString = (config: QueryObject, configKey?: string): string => {
+  const pairs: string[] = [];
+
+  Object.entries(config).forEach(([key, value]) => {
+    const nestedKey = configKey ? `${configKey}[${encodeURIComponent(key)}]` : encodeURIComponent(key);
+    const valueIsObject = typeof value === 'object' && value !== null && !Array.isArray(value);
+
+    if (valueIsObject) {
+      pairs.push(buildQueryString(value as QueryObject, nestedKey));
+    } else {
+      pairs.push(`${nestedKey}=${encodeURIComponent(String(value))}`);
+    }
+  });
+
+  return pairs.join('&');
+};
 
 export const buildMessageHandler = (handlers: FintocWidgetEventHandlers) => (
   (event: WebViewMessageEvent) => {


### PR DESCRIPTION
## Description
The `username` in the configuration options now has to be provided as an object. The `buildQueryString` method now stringifies the configuration data if it's an object.

The object:
```JS
options:  {
  "country": "cl",
  "holder_type": "individual",
  "product": "payments",
  "public_key": "pk_live_XXX",
  "username": {
    "editable": false,
    "value": "19518958-7"
  },
  "widget_token": "pi_XXX"
};
```

Gets turned into:
```JS
queryString = "public_key=pk_live_XXX&holder_type=individual&product=payments&username[value]=19518958-7&username[editable]=false&country=cl&widget_token=pi_XXX"
```

## Requirements
- [x] Update the [Fintoc Widget Web View](https://github.com/fintoc-com/wizard/pull/655) to parse the `username` and `preselectedUsername` before sending them over to the script.

## Additional changes
None.
